### PR TITLE
chore: bump Copilot agent Flutter version to 3.41.5

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,7 +29,7 @@ jobs:
             - name: Set up Flutter
               uses: subosito/flutter-action@v2
               with:
-                  flutter-version: '3.22.0'
+                  flutter-version: '3.41.5'
                   channel: 'stable'
                   cache: true
 


### PR DESCRIPTION
## Summary

- Bumps the Flutter version pinned in [.github/workflows/copilot-setup-steps.yml](.github/workflows/copilot-setup-steps.yml) from `3.22.0` to `3.41.5`
- Aligns the Copilot agent's runner with the local development SDK so `pubspec.lock` no longer drifts on every Copilot PR

## Why

The Copilot setup workflow pinned an older Flutter (3.22.0, ships Dart ~3.4) than `pubspec.yaml` actually requires (`^3.11.3`). When the agent ran `flutter pub get` on its runner, the older pub solver picked older transitive dependency versions and silently rewrote `pubspec.lock` — most recently in PR #35, where 96 lines of unintended downgrades had to be reverted.

Bumping the pin to match the local SDK (3.41.5 / Dart 3.11.3) keeps all three environments — laptop, Copilot runner, and any future CI — on the same pub solver, so lockfile drift stops at source.

## Test plan

- [ ] Workflow file is the only change
- [ ] After merge, the next Copilot-authored PR should leave `pubspec.lock` untouched
- [ ] Watch the next workflow run on this PR (it triggers via `pull_request` paths matching the workflow file itself) to confirm `flutter pub get` succeeds on 3.41.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)