### PR TITLE
Encode confirmed b/p/g/q second-stroke startRects (#87)

### DIFF
--- a/lib/models/letter_formation_registry.dart
+++ b/lib/models/letter_formation_registry.dart
@@ -35,6 +35,10 @@ import 'stroke_start_rect.dart';
 /// | i      | 1      | 0.15–0.85  | 0.00–0.36  | Generous dot zone         |
 /// | j      | 0      | 0.25–0.75  | 0.00–0.15  | Centred stem              |
 /// | j      | 1      | 0.15–0.85  | 0.00–0.25  | Generous dot zone         |
+/// | b      | 1      | 0.00–0.20  | 0.40–0.60  | Mid-left bowl at x-height |
+/// | p      | 1      | 0.00–0.20  | 0.35–0.50  | Left bowl just below x-height (descender bounds) |
+/// | g      | 1      | 0.70–1.00  | 0.35–0.55  | Mid-right link/tail at x-height |
+/// | q      | 1      | 0.75–1.00  | 0.45–0.65  | Right descender above baseline (descender bounds) |
 ///
 /// ## Single-stroke letters — `c, e, l, o, s, v, w, z`
 ///
@@ -242,7 +246,7 @@ final Map<String, LetterFormationData> letterFormationRegistry = {
       ExpectedStroke(
         primaryDirection: StrokeDirection.clockwise,
         startRegion: StrokeStartRegion.top,
-        startRect: const StrokeStartRect(minX: 0.00, maxX: 0.25, minY: 0.00, maxY: 0.15),
+        startRect: const StrokeStartRect(minX: 0.00, maxX: 0.20, minY: 0.40, maxY: 0.60),
       ),
     ],
   ),
@@ -272,7 +276,7 @@ final Map<String, LetterFormationData> letterFormationRegistry = {
       ExpectedStroke(
         primaryDirection: StrokeDirection.topToBottom,
         startRegion: StrokeStartRegion.top,
-        startRect: const StrokeStartRect(minX: 0.75, maxX: 1.00, minY: 0.00, maxY: 0.15),
+        startRect: const StrokeStartRect(minX: 0.70, maxX: 1.00, minY: 0.35, maxY: 0.55),
       ),
     ],
   ),
@@ -287,7 +291,7 @@ final Map<String, LetterFormationData> letterFormationRegistry = {
       ExpectedStroke(
         primaryDirection: StrokeDirection.clockwise,
         startRegion: StrokeStartRegion.top,
-        startRect: const StrokeStartRect(minX: 0.00, maxX: 0.25, minY: 0.00, maxY: 0.15),
+        startRect: const StrokeStartRect(minX: 0.00, maxX: 0.20, minY: 0.35, maxY: 0.50),
       ),
     ],
   ),
@@ -302,7 +306,7 @@ final Map<String, LetterFormationData> letterFormationRegistry = {
       ExpectedStroke(
         primaryDirection: StrokeDirection.topToBottom,
         startRegion: StrokeStartRegion.top,
-        startRect: const StrokeStartRect(minX: 0.75, maxX: 1.00, minY: 0.00, maxY: 0.15),
+        startRect: const StrokeStartRect(minX: 0.75, maxX: 1.00, minY: 0.45, maxY: 0.65),
       ),
     ],
   ),

--- a/test/letter_formation_registry_test.dart
+++ b/test/letter_formation_registry_test.dart
@@ -635,28 +635,30 @@ void main() {
           const StrokeStartRect(minX: 0.15, maxX: 0.85, minY: 0.00, maxY: 0.25));
     });
 
-    // ── Unlisted second strokes (b[1], g[1], p[1], q[1]) ────────────────────
-    // These strokes are not in the agreed groups/overrides table; values are
-    // assigned based on the letter's geometry:
-    //   b[1], p[1] — bowl re-traced from same top-left origin as stem
-    //   g[1], q[1] — descender/stem starting upper-right of the oval
+    // ── Confirmed second strokes (b[1], p[1], g[1], q[1]) ───────────────────
+    // Design-review-confirmed rectangles (see issue #87). These replaced the
+    // PR #86 placeholders (stem-first / upper-right defaults) once the
+    // pedagogical start zones for the bowl/link/tail second strokes were
+    // agreed.
 
-    test('b[1]: top-left bowl origin (0.00–0.25, 0.00–0.15)', () {
-      expect(rect('b', 1), stemRect);
+    test('b[1]: mid-left bowl at x-height (0.00–0.20, 0.40–0.60)', () {
+      expect(rect('b', 1),
+          const StrokeStartRect(minX: 0.00, maxX: 0.20, minY: 0.40, maxY: 0.60));
     });
 
-    test('p[1]: top-left bowl origin (0.00–0.25, 0.00–0.15)', () {
-      expect(rect('p', 1), stemRect);
+    test('p[1]: left bowl just below x-height (0.00–0.20, 0.35–0.50)', () {
+      expect(rect('p', 1),
+          const StrokeStartRect(minX: 0.00, maxX: 0.20, minY: 0.35, maxY: 0.50));
     });
 
-    test('g[1]: upper-right tail origin (0.75–1.00, 0.00–0.15)', () {
+    test('g[1]: mid-right link/tail at x-height (0.70–1.00, 0.35–0.55)', () {
       expect(rect('g', 1),
-          const StrokeStartRect(minX: 0.75, maxX: 1.00, minY: 0.00, maxY: 0.15));
+          const StrokeStartRect(minX: 0.70, maxX: 1.00, minY: 0.35, maxY: 0.55));
     });
 
-    test('q[1]: upper-right stem origin (0.75–1.00, 0.00–0.15)', () {
+    test('q[1]: right descender above baseline (0.75–1.00, 0.45–0.65)', () {
       expect(rect('q', 1),
-          const StrokeStartRect(minX: 0.75, maxX: 1.00, minY: 0.00, maxY: 0.15));
+          const StrokeStartRect(minX: 0.75, maxX: 1.00, minY: 0.45, maxY: 0.65));
     });
   });
 }


### PR DESCRIPTION
## Summary

- Replace PR #86 placeholder `startRect` values for `b[1]`, `p[1]`, `g[1]`, `q[1]` with the design-review-confirmed coordinates
- Extend the file-header override table in `letter_formation_registry.dart` with these four entries
- Update `test/letter_formation_registry_test.dart` to assert the new coordinates exactly

| Letter | Stroke | x | y | Notes |
|---|---|---|---|---|
| b | 1 (bowl) | 0.00–0.20 | 0.40–0.60 | Mid-left at x-height |
| p | 1 (bowl) | 0.00–0.20 | 0.35–0.50 | Left side just below x-height (descender bounds) |
| g | 1 (link/tail) | 0.70–1.00 | 0.35–0.55 | Mid-right at x-height |
| q | 1 (descender) | 0.75–1.00 | 0.45–0.65 | Right side just above baseline (descender bounds) |

Closes #87.

## Test plan

- [x] `flutter test test/letter_formation_registry_test.dart` — 172 tests pass, including the four updated `b[1]/p[1]/g[1]/q[1]` assertions
- [x] `flutter test` — full suite (577 tests) passes