### PR TITLE
fix: restore canonical WaypointSection API in letter_formation_data_test (main is red)

### DIFF
--- a/test/letter_formation_data_test.dart
+++ b/test/letter_formation_data_test.dart
@@ -104,14 +104,30 @@ void main() {
           minY: 0.0,
           maxY: 1.0 / 3.0,
         ),
-        sections: const [
-          WaypointSection(index: 0, minX: 0.0, maxX: 0.5, minY: 0.0, maxY: 0.5),
-          WaypointSection(index: 1, minX: 0.5, maxX: 1.0, minY: 0.5, maxY: 1.0),
+        sections: [
+          WaypointSection(
+            number: 1,
+            rect: const StrokeStartRect(
+              minX: 0.0,
+              maxX: 0.5,
+              minY: 0.0,
+              maxY: 0.5,
+            ),
+          ),
+          WaypointSection(
+            number: 2,
+            rect: const StrokeStartRect(
+              minX: 0.5,
+              maxX: 1.0,
+              minY: 0.5,
+              maxY: 1.0,
+            ),
+          ),
         ],
       );
       expect(stroke.sections.length, 2);
-      expect(stroke.sections[0].index, 0);
-      expect(stroke.sections[1].index, 1);
+      expect(stroke.sections[0].number, 1);
+      expect(stroke.sections[1].number, 2);
     });
 
     test('can have both waypoints and sections simultaneously', () {
@@ -123,9 +139,25 @@ void main() {
           maxY: 1.0 / 3.0,
         ),
         waypoints: [WaypointRegion.top, WaypointRegion.bottom],
-        sections: const [
-          WaypointSection(index: 0, minX: 0.0, maxX: 1.0, minY: 0.0, maxY: 0.5),
-          WaypointSection(index: 1, minX: 0.0, maxX: 1.0, minY: 0.5, maxY: 1.0),
+        sections: [
+          WaypointSection(
+            number: 1,
+            rect: const StrokeStartRect(
+              minX: 0.0,
+              maxX: 1.0,
+              minY: 0.0,
+              maxY: 0.5,
+            ),
+          ),
+          WaypointSection(
+            number: 2,
+            rect: const StrokeStartRect(
+              minX: 0.0,
+              maxX: 1.0,
+              minY: 0.5,
+              maxY: 1.0,
+            ),
+          ),
         ],
       );
       expect(stroke.waypoints, [WaypointRegion.top, WaypointRegion.bottom]);


### PR DESCRIPTION
## Problem

`test/letter_formation_data_test.dart` on `main` uses the old `index:`/flattened `WaypointSection` API (`WaypointSection(index: 0, minX:…, maxX:…, minY:…, maxY:…)` and `.index`), which does not exist on the canonical model (`number` + composed `StrokeStartRect rect`). As a result **`main` does not compile** — `flutter test` fails to load that file.

## Root cause

During the PR #123 rework the test was corrected to `number:`/`rect:`, but the corrections were left as uncommitted working-tree changes and never made it into the pushed commit, so the merge regressed the file back to the `index:` version.

## Fix

Update the two `sections:` tests to the canonical API:
- `WaypointSection(index: 0/1, minX/…)` → `WaypointSection(number: 1/2, rect: StrokeStartRect(...))`
- `.index` assertions → `.number`
- `const [...]` → non-const list (the canonical constructor is not `const`)

Full suite green locally (625 tests).