### PR TITLE
Phase C / Step 5: Wire WaypointSectionScorer into ScoreIntegrator

### DIFF
--- a/lib/models/score_integrator.dart
+++ b/lib/models/score_integrator.dart
@@ -12,6 +12,7 @@ import 'stroke.dart';
 import 'stroke_break_counter.dart';
 import 'stroke_rasterizer.dart';
 import 'stroke_start_scorer.dart';
+import 'waypoint_section_scorer.dart';
 
 /// Rasterizes user strokes and scores them against a reference mask.
 class ScoreIntegrator {
@@ -109,11 +110,24 @@ class ScoreIntegrator {
           bounds: formationBounds,
         ).score(strokes);
 
-        compoundStroke = CompoundStrokeScorer(
-          letter: letter,
-          data: data,
-          bounds: formationBounds,
-        ).score(strokes);
+        // Path scoring: route a letter to the bespoke section scorer once it
+        // has been migrated to carry `sections`; otherwise use the legacy 3×3
+        // WaypointRegion grid scorer. Both produce a FormationScore, so the
+        // ScoreResult.compoundStroke field and the UI are unaffected.
+        // NOTE: the section branch gets real integration coverage in Phase D,
+        // when the first letter is migrated to use `sections`.
+        final usesSections = data.strokes.any((s) => s.sections.isNotEmpty);
+        compoundStroke = usesSections
+            ? WaypointSectionScorer(
+                letter: letter,
+                data: data,
+                bounds: formationBounds,
+              ).score(strokes)
+            : CompoundStrokeScorer(
+                letter: letter,
+                data: data,
+                bounds: formationBounds,
+              ).score(strokes);
 
         strokeBreak = StrokeBreakCounter(
           letter: letter,


### PR DESCRIPTION
Phase C / Step 5 of the WaypointSection migration: route path scoring per letter.

## Change

In `ScoreIntegrator.score()`, the path-scoring step now selects the scorer based on the letter's data:
- if any expected stroke has a non-empty `sections` list → `WaypointSectionScorer` (new, all-or-nothing pass/fail),
- otherwise → `CompoundStrokeScorer` (legacy 3×3 `WaypointRegion` grid), as today.

Both return a `FormationScore`, so `ScoreResult.compoundStroke` and the "Path" UI row are unaffected.

## Testing

No bespoke test added: no registry letter carries `sections` yet, so the section branch has nothing real to exercise until Phase D migrates the first letter — at which point it gets genuine integration coverage. A code comment notes this. Existing integrator tests still cover the compound path (all current letters route to `CompoundStrokeScorer`).

Full suite green: **645 tests**.

## Dependencies

- Step 4 (`WaypointSectionScorer`) — ✅ merged (#126).
- Unblocks Phase D (per-letter data migration), which will exercise this branch end-to-end.